### PR TITLE
Resolves "Empty list of contents if you call Filesystem::listContents() on root path of share"

### DIFF
--- a/src/SmbAdapter.php
+++ b/src/SmbAdapter.php
@@ -383,7 +383,7 @@ class SmbAdapter extends AbstractAdapter
     {
         $normalized = [
             'type' => $file->isDirectory() ? 'dir' : 'file',
-            'path' => $this->getFilePath($file),
+            'path' => ltrim($this->getFilePath($file), $this->pathSeparator),
             'timestamp' => $file->getMTime()
         ];
 


### PR DESCRIPTION
Left trim the path separator in order to get `\League\Flysystem\Util\ContentListingFormatter::isDirectChild` return true and get the listing of the root folder of a share.

fixes https://github.com/robgridley/flysystem-smb/issues/2