### PR TITLE
Don't read entire file into memory to determine its mime type

### DIFF
--- a/src/SmbAdapter.php
+++ b/src/SmbAdapter.php
@@ -351,13 +351,14 @@ class SmbAdapter extends AbstractAdapter
      */
     public function getMimetype($path)
     {
-        $metadata = $this->read($path);
+        $metadata = $this->readStream($path);
 
         if ($metadata === false) {
             return false;
         }
 
-        $metadata['mimetype'] = Util::guessMimeType($path, $metadata['contents']);
+        $metadata['mimetype'] = Util::guessMimeType($path, stream_get_contents($metadata['stream'], 65536));
+        rewind($metadata['stream']);
 
         return $metadata;
     }


### PR DESCRIPTION
``getMimetype()`` currently reads the entire file into memory to determine the mime type.  Reading an entire file, especially over a network connection can be expensive. Further, if the file is large, it will out-of-memory PHP.

Change the implementation to read a 64KB chunk instead.